### PR TITLE
fix: Resolve deprecation warnings

### DIFF
--- a/example/src/example.js
+++ b/example/src/example.js
@@ -2,14 +2,10 @@ var React = require('react');
 var ReactDOM = require('react-dom');
 var ReactRotatingText = require('react-rotating-text');
 
-var App = React.createClass({
-	render () {
-		return (
-			<div className="display-text">
-				<ReactRotatingText />
-			</div>
-		);
-	}
-});
+var App = () => (
+  <div className="display-text">
+    <ReactRotatingText />
+  </div>
+);
 
 ReactDOM.render(<App />, document.getElementById('app'));

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "url": "https://github.com/adrianmc/react-rotating-text/issues"
   },
   "dependencies": {
-    "classnames": "^2.1.2"
+    "classnames": "^2.1.2",
+    "prop-types": "^15.5.10"
   },
   "devDependencies": {
     "babel-eslint": "^4.1.3",

--- a/src/ReactRotatingText.js
+++ b/src/ReactRotatingText.js
@@ -1,4 +1,5 @@
 var React = require('react');
+var PropTypes = require('prop-types');
 
 class ReactRotatingText extends React.Component {
 
@@ -132,14 +133,14 @@ class ReactRotatingText extends React.Component {
 }
 
 ReactRotatingText.propTypes = {
-  color: React.PropTypes.string,
-  cursor: React.PropTypes.bool,
-  deletingInterval: React.PropTypes.number,
-  emptyPause: React.PropTypes.number,
-  eraseMode: React.PropTypes.string,
-  items: React.PropTypes.array,
-  pause: React.PropTypes.number,
-  typingInterval: React.PropTypes.number,
+  color: PropTypes.string,
+  cursor: PropTypes.bool,
+  deletingInterval: PropTypes.number,
+  emptyPause: PropTypes.number,
+  eraseMode: PropTypes.string,
+  items: PropTypes.array,
+  pause: PropTypes.number,
+  typingInterval: PropTypes.number,
 };
 
 ReactRotatingText.defaultProps = {


### PR DESCRIPTION
- Accessing PropTypes via the main React package is deprecated
- Accessing createClass via the main React package is deprecated

I don't use `yarn` so I did not include an updated `yarn.lock`. I can send over a `package-lock.json` produced by `npm@5.x` if you are interested.

👍  Thanks for creating a nice component! I had been trying to use [`react-typewriter`](https://github.com/ianbjorndilling/react-typewriter) and reimplemented nearly exactly what you have here on top of it.