### PR TITLE
Shift text with multiple-byte characters correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "classnames": "^2.1.2",
+    "lodash.toarray": "^4.4.0",
     "prop-types": "^15.5.10"
   },
   "devDependencies": {

--- a/src/ReactRotatingText.js
+++ b/src/ReactRotatingText.js
@@ -1,5 +1,6 @@
 var React = require('react');
 var PropTypes = require('prop-types');
+var toArray = require('lodash.toarray');
 
 class ReactRotatingText extends React.Component {
 
@@ -38,12 +39,13 @@ class ReactRotatingText extends React.Component {
     const { output } = this.state;
     const { typingInterval } = this.props;
     const loopingFunc = this._type.bind(this, text, callback);
+    const word = toArray(text)
 
     // set the string one character longer
-    this.setState({output: text.substr(0, output.length + 1)});
+    this.setState({output: word.slice(0, toArray(output).length + 1).join('')});
 
     // if we're still not done, recursively loop again
-    if (output.length < text.length) {
+    if (output.length < word.length) {
       this._loop(loopingFunc, typingInterval);
     } else {
       callback();
@@ -54,12 +56,13 @@ class ReactRotatingText extends React.Component {
     const { output } = this.state;
     const { deletingInterval } = this.props;
     const loopingFunc = this._erase.bind(this, callback);
+    const word = toArray(output)
 
     // set the string one character shorter
-    this.setState({output: output.substr(0, output.length - 1)});
+    this.setState({output: word.slice(0, word.length - 1).join('')});
 
     // if we're still not done, recursively loop again
-    if (output.length !== 0) {
+    if (word.length !== 0) {
       this._loop(loopingFunc, deletingInterval);
     } else {
       callback();
@@ -70,13 +73,15 @@ class ReactRotatingText extends React.Component {
     const { output, substrLength } = this.state;
     const { deletingInterval } = this.props;
     const loopingFunc = this._overwrite.bind(this, text, callback);
+    const word = toArray(text)
+    const out = toArray(output)
 
     this.setState({
-      output: text.substr(0, substrLength) + output.substr(substrLength),
+      output: word.slice(0, substrLength).concat(out.slice(substrLength)),
       substrLength: substrLength + 1,
     });
 
-    if (text.length !== substrLength) {
+    if (word.length !== substrLength) {
       this._loop(loopingFunc, deletingInterval);
     } else {
       this.setState({

--- a/yarn.lock
+++ b/yarn.lock
@@ -3225,6 +3225,11 @@ lodash.templatesettings@^3.0.0:
     lodash._reinterpolate "^3.0.0"
     lodash.escape "^3.0.0"
 
+lodash.toarray@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.toarray/-/lodash.toarray-4.4.0.tgz#24c4bfcd6b2fba38bfd0594db1179d8e9b656561"
+  integrity sha1-JMS/zWsvuji/0FlNsRedjptlZWE=
+
 lodash.toplainobject@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash.toplainobject/-/lodash.toplainobject-3.0.0.tgz#28790ad942d293d78aa663a07ecf7f52ca04198d"


### PR DESCRIPTION
Shifts text using `lodash.toArray` rather than `substr`.

This is done to resolve an issue with emojis
and other Unicode characters
which take multiple bytes to represent.

These Unicode characters are represented as multiple joined characters
which means that shifting the string by one will result in
a broken or unwanted character being displayed.

`lodash.toArray` correctly splits these Unicode characters
into a single slot in the array preventing this from happening.

**Prior to this change:**

![emoji-bad-long](https://user-images.githubusercontent.com/7284672/54861862-a541ef80-4cee-11e9-886d-619a28dc222d.gif)

Notice the `?` character which is displayed for one cycle.


**Change applied:**

![emoji-good-long](https://user-images.githubusercontent.com/7284672/54861867-aa9f3a00-4cee-11e9-8ba2-7398cc301165.gif)

