### PR TITLE
Add license information

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,9 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Adrian Li.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "bugs": {
     "url": "https://github.com/adrianmc/react-rotating-text/issues"
   },
+  "license": "MIT",
   "dependencies": {
     "classnames": "^2.1.2",
     "lodash.toarray": "^4.4.0",


### PR DESCRIPTION
This PR addresses and fixes #24 and adds the license [SPDX identifier](https://spdx.org/licenses/MIT.html) to the [`package.json`'s `license` field](https://docs.npmjs.com/cli/v6/configuring-npm/package-json#license). It also copies the license information from `Readme.md` to a separate `LICENSE` file.